### PR TITLE
Fix React Server Components CVE vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "html-react-parser": "^5.2.7",
         "lodash": "^4.17.21",
         "lucide-react": "^0.554.0",
-        "next": "^14.2.33",
+        "next": "14.2.35",
         "next-themes": "^0.2.1",
         "nextjs-toploader": "^3.9.17",
         "react": "^18",
@@ -275,9 +275,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.33.tgz",
-      "integrity": "sha512-CgVHNZ1fRIlxkLhIX22flAZI/HmpDaZ8vwyJ/B0SDPTBuLZ1PJ+DWMjCHhqnExfmSQzA/PbZi8OAc7PAq2w9IA==",
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.35.tgz",
+      "integrity": "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -4057,12 +4057,12 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.33.tgz",
-      "integrity": "sha512-GiKHLsD00t4ACm1p00VgrI0rUFAC9cRDGReKyERlM57aeEZkOQGcZTpIbsGn0b562FTPJWmYfKwplfO9EaT6ng==",
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
+      "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "14.2.33",
+        "@next/env": "14.2.35",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "html-react-parser": "^5.2.7",
     "lodash": "^4.17.21",
     "lucide-react": "^0.554.0",
-    "next": "^14.2.33",
+    "next": "14.2.35",
     "next-themes": "^0.2.1",
     "nextjs-toploader": "^3.9.17",
     "react": "^18",


### PR DESCRIPTION
Updated dependencies to fix Next.js and React CVE vulnerabilities.

The fix-react2shell-next tool automatically updated the following packages to their secure versions:
- next
- react-server-dom-webpack
- react-server-dom-parcel  
- react-server-dom-turbopack

All package.json files have been scanned and vulnerable versions have been patched to the correct fixed versions based on the official React advisory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Next.js dependency to version 14.2.35 for enhanced performance, stability, and security improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->